### PR TITLE
l3_interface: Fix handling ipv4 only aggregate

### DIFF
--- a/library/nmstate_l3_interface.py
+++ b/library/nmstate_l3_interface.py
@@ -145,10 +145,10 @@ class AnsibleNMStateL3Interface(AnsibleNMState):
 
             if self.params["purge"]:
                 updated_ipconfig = set_addresses(ipconfig, addresses)
+                interface_state[protocol] = updated_ipconfig
             elif addresses:
                 updated_ipconfig = add_addresses(ipconfig, addresses)
-
-            interface_state[protocol] = updated_ipconfig
+                interface_state[protocol] = updated_ipconfig
 
         return interface_state
 


### PR DESCRIPTION
For each protocol, the updated ipconfig should be only set if it was
created. Otherwise the ipv4 ipconfig might be used for ipv6, if ipv6 was
not specified.