### PR TITLE
Use YAML for debug file instead of JSON

### DIFF
--- a/module_utils/ansible_nmstate.py
+++ b/module_utils/ansible_nmstate.py
@@ -18,7 +18,6 @@
 #
 
 from copy import deepcopy
-import json
 import os
 import tempfile
 import time
@@ -26,14 +25,15 @@ import time
 
 from libnmstate import netapplier
 from libnmstate import netinfo
+from libnmstate import prettystate
 
 
 def write_debug_state(module_name, state):
     debugfile, debugname = tempfile.mkstemp(
-        prefix="{}_debug-{}-".format(module_name, int(time.time()))
+        prefix="{}_debug-{}-".format(module_name, int(time.time())), suffix=".yml"
     )
     debugfile = os.fdopen(debugfile, "w")
-    debugfile.write(json.dumps(state, indent=4))
+    debugfile.write(prettystate.PrettyState(state).yaml)
 
     return debugname
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skip_missing_interpreters = True
 basepython = python2.7
 deps =
     py{27,36,37}: pytest-cov
-    py{27,36,37}: nmstate
+    py{27,36,37}: nmstate>=0.0.4
     py{27,36,37}: pytest>=3.5.1
     py27: mock
 


### PR DESCRIPTION
nmstate started to use YAML by default, therefore do the same for the
Ansible modules.